### PR TITLE
Use the new stats API to show btc deposit total.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -58,7 +58,7 @@ const QUERY_TOKEN_STAKINGS = `
 
 const QUERY_ACTIVE_DEPOSITS = `
 {
-  stats(id: "current") { btcUnderDeposit }  
+  stats: statsRecord(id: "current") { btcUnderDeposit }  
 }`
 
 const initForQuery = (query) => ({

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -58,7 +58,7 @@ const QUERY_TOKEN_STAKINGS = `
 
 const QUERY_ACTIVE_DEPOSITS = `
 {
-  stats: statsRecord(id: "current") { btcUnderDeposit }  
+  stats: statsRecord(id: "current") { btcInActiveDeposits }  
 }`
 
 const initForQuery = (query) => ({

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -56,12 +56,9 @@ const QUERY_TOKEN_STAKINGS = `
   }
 }`
 
-// We need to do this differently to support more than 1000 queries, a limit of the API
 const QUERY_ACTIVE_DEPOSITS = `
 {
-  deposits(where: {currentState: ACTIVE}, first: 1000) {
-    lotSizeSatoshis
-  }
+  stats(id: "current") { btcUnderDeposit }  
 }`
 
 const initForQuery = (query) => ({
@@ -170,8 +167,7 @@ class App extends React.Component {
         tbtcBurn: results[3].data.tbtctokens[0].totalBurn,
         tbtcHolders: results[3].data.tbtctokens[0].currentTokenHolders,
         deposits: results[4].data.totalBondedECDSAKeeps[0].totalKeepActive,
-        depositedBTC: results[7].data.deposits
-          .reduce((total, keep) => total.plus(keep.lotSizeSatoshis), Big('0'))
+        depositedBTC: Big(results[7].data.stats.btcUnderDeposit)
           .div(10 ** 8)
           .toFixed(2),
         depositValue: 0,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -167,7 +167,7 @@ class App extends React.Component {
         tbtcBurn: results[3].data.tbtctokens[0].totalBurn,
         tbtcHolders: results[3].data.tbtctokens[0].currentTokenHolders,
         deposits: results[4].data.totalBondedECDSAKeeps[0].totalKeepActive,
-        depositedBTC: Big(results[7].data.stats.btcUnderDeposit)
+        depositedBTC: Big(results[7].data.stats.btcInActiveDeposits)
           .div(10 ** 8)
           .toFixed(2),
         depositValue: 0,


### PR DESCRIPTION
As per your suggestion, a field that reads the total value. Note I wrote this in Github, so it may not work.

Also,  `btcUnderDeposit` is a bit different than the existing code in that it only removes BTC once the deposit enters "FUNDING" state (as opposed to "ACTIVE"), the logic being that until we have proof that the BTC left the system, we assume they are still there.

I now am starting to question that decision, because we don't really, of course, know when the bitcoin are gone, and since the redemption process, once initiated, can't really be stopped, we might argue that at that point we can assume the value to be out of the system.

Thoughts?

Strictly speaking, filtering for ACTIVE isn't exactly right either, ignoring the possibility of COURTESY_CALL.